### PR TITLE
Update spCore.cpp - for ESP32 v2.0.3

### DIFF
--- a/src/Spark/spCore.cpp
+++ b/src/Spark/spCore.cpp
@@ -76,10 +76,13 @@ size_t spIProperty::save_size(void){
 static uint16_t id_hash(const char* str){
 
 	uint32_t hash = 5381;
-    int c;
+    int c = *str;
 
-    while (c = *str++)
+    while (c != 0)
+	{
+		c = *str++;
         hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+	}
 
     return  hash & 0xFFFF; // NOTE - we're just using 16 bits 
 


### PR DESCRIPTION
ESP32 v2.0.3 throws an error on ```while (c = *str++)``` 

This PR changes the code - slightly - to make the error go away...