### PR TITLE
Update flxDevADS1015.cpp - correct set_pga_gain (setGain)

### DIFF
--- a/src/Flux/flxDevADS1015.cpp
+++ b/src/Flux/flxDevADS1015.cpp
@@ -176,5 +176,5 @@ void flxDevADS1015::set_pga_gain(uint16_t gain)
 {
     _gain = gain;
     if (_begun)
-        ADS1015::setSampleRate(gain);
+        ADS1015::setGain(gain);
 }


### PR DESCRIPTION
This is a fix for the ADS1015 gain.

Previously, the gain would be fixed at the device default of 1mV per LSB. And the sample rate would always be 128Hz.

I'll leave it up to you to merge this wherever you like. In main, or the ads_type_additions branch. Or just delete this and fix it elsewhere...!