### PR TITLE
fix issue with value types for the bmp384 device -- double values needed

### DIFF
--- a/src/core/flux_base/flxDeviceValueTypes.h
+++ b/src/core/flux_base/flxDeviceValueTypes.h
@@ -162,3 +162,9 @@ const flxParamValueType_t kParamValueBatteryVoltage = 48;
 
 // Battery Charge Rate %/hr - Battery charge rate %/hr - float value
 const flxParamValueType_t kParamValueBatteryChargeRate = 49;
+
+// Temperature (C)  - Double value
+const flxParamValueType_t kParamValueTempC_D = 50;
+
+// Pressure - double value
+const flxParamValueType_t kParamValuePressure_D = 51;

--- a/src/device/device_bmp384/flxDevBMP384.cpp
+++ b/src/device/device_bmp384/flxDevBMP384.cpp
@@ -50,8 +50,8 @@ flxDevBMP384::flxDevBMP384()
     setDescription("The Bosch BMP384 Pressure and Temperature Sensor");
 
     // Register parameters
-    flxRegister(temperatureC, "Temperature (C)", "The sensed temperature in degrees Celsius", kParamValueTempC);
-    flxRegister(pressure, "Pressure (Pa)", "The sensed pressure in Pascals", kParamValueHumidity_F);
+    flxRegister(temperatureC, "Temperature (C)", "The sensed temperature in degrees Celsius", kParamValueTempC_D);
+    flxRegister(pressure, "Pressure (Pa)", "The sensed pressure in Pascals", kParamValuePressure_D);
 }
 
 //----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Pull in the minor change made after the lorawan release branch was created. 