### PR TITLE
Feature/soil moisture sensor

### DIFF
--- a/library-list.txt
+++ b/library-list.txt
@@ -58,3 +58,4 @@ SdFat
 "SparkFun Indoor Air Quality Sensor - ENS160"
 "SparkFun Color Sensor OPT4048"
 "SparkFun Spectral Triad AS7265X"
+"SparkFun Soil Moisture Sensor"

--- a/library-list.txt
+++ b/library-list.txt
@@ -58,4 +58,3 @@ SdFat
 "SparkFun Indoor Air Quality Sensor - ENS160"
 "SparkFun Color Sensor OPT4048"
 "SparkFun Spectral Triad AS7265X"
-"SparkFun Soil Moisture Sensor"

--- a/src/core/flux_base/flxCoreDevice.cpp
+++ b/src/core/flux_base/flxCoreDevice.cpp
@@ -56,7 +56,9 @@ void flxDevice::addAddressToName()
         return;
 
     char szBuffer[64];
-    snprintf(szBuffer, sizeof(szBuffer), getKind() == flxDeviceKindSPI ? "%s [p%d]" : "%s [x%x]", name(), address());
+    snprintf(szBuffer, sizeof(szBuffer),
+             getKind() == flxDeviceKindSPI || getKind() == flxDeviceKindGPIO ? "%s [p%d]" : "%s [x%x]", name(),
+             address());
 
     setName(szBuffer);
 }

--- a/src/core/flux_base/flxCoreDevice.h
+++ b/src/core/flux_base/flxCoreDevice.h
@@ -39,6 +39,7 @@ typedef enum
 {
     flxDeviceKindI2C,
     flxDeviceKindSPI,
+    flxDeviceKindGPIO,
     flxDeviceKindNone
 } flxDeviceKind_t;
 

--- a/src/core/flux_base/flxCoreProps.h
+++ b/src/core/flux_base/flxCoreProps.h
@@ -1974,7 +1974,7 @@ template <class T> class flxContainer : public flxObject
         // make sure the value isn't already in the list...
         if (std::find(_vector.begin(), _vector.end(), value) != _vector.end())
         {
-            flxLogM_I(kMsgNotAddDupDev, name());
+            flxLogM_V(kMsgNotAddDupDev, name());
             return;
         }
         _vector.push_back(value);
@@ -2063,6 +2063,15 @@ template <class T> class flxContainer : public flxObject
             return;
 
         _vector.erase(it);
+    }
+
+    // Does this vector contains a value?
+    bool contains(T value)
+    {
+        // in the vector?
+        iterator it = std::find(_vector.begin(), _vector.end(), value);
+
+        return it != _vector.end();
     }
 
     // Defines a type specific static method - so can be called outside

--- a/src/core/flux_base/flxDevice.h
+++ b/src/core/flux_base/flxDevice.h
@@ -309,6 +309,21 @@ template <typename T> class flxDeviceGPIOType : public flxDevice
     // The typeID is determined by hashing the name of the class.
     // This way the type ID is consistent across invocations
 
+    // virtual catch method if subclass forgets to implement it
+    virtual bool onInitialize(void)
+    {
+        return true;
+    }
+
+    // a wrapper that the system can use for GPIO device
+    bool initialize(void)
+    {
+
+        bool status = onInitialize();
+        setIsInitialized(status);
+        return status;
+    }
+
     static flxTypeID type(void)
     {
         static flxTypeID _myTypeID = flxGetClassTypeID<T>();

--- a/src/core/flux_base/flxDevice.h
+++ b/src/core/flux_base/flxDevice.h
@@ -285,3 +285,56 @@ template <typename T, typename B = flxDevice> class flxDeviceSPIType : public B
         return kind();
     }
 };
+
+//----------------------------------------------------------------------------------
+// GPIO device classes
+//----------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------
+// flxDeviceGPIOType()
+//
+// A simple base class that a GPIO based device can be build off of.
+// This basically exists to help with type definition.  The actual device impl needs to
+// needs to provide the required initialize() method for it's specific needs
+//
+//
+template <typename T> class flxDeviceGPIOType : public flxDevice
+{
+  public:
+    // Typing system for devices
+    //
+    // Defines a type specific static method - so can be called outside
+    // of an instance.
+    //
+    // The typeID is determined by hashing the name of the class.
+    // This way the type ID is consistent across invocations
+
+    static flxTypeID type(void)
+    {
+        static flxTypeID _myTypeID = flxGetClassTypeID<T>();
+
+        return _myTypeID;
+    }
+
+    // Return the type ID of this
+    flxTypeID getType(void)
+    {
+        return type();
+    }
+
+    bool isType(flxTypeID type)
+    {
+        return type == getType();
+    }
+
+    // Device Kind Typing
+    static flxDeviceKind_t kind(void)
+    {
+        return flxDeviceKindGPIO;
+    }
+
+    flxDeviceKind_t getKind(void)
+    {
+        return kind();
+    }
+};

--- a/src/core/flux_base/flxDevice.h
+++ b/src/core/flux_base/flxDevice.h
@@ -321,6 +321,11 @@ template <typename T> class flxDeviceGPIOType : public flxDevice
 
         bool status = onInitialize();
         setIsInitialized(status);
+
+        // Call the super class version of this method.
+        // It ensures that the device is added to the system
+        flxDevice::initialize();
+
         return status;
     }
 

--- a/src/core/flux_base/flxDeviceValueTypes.h
+++ b/src/core/flux_base/flxDeviceValueTypes.h
@@ -168,3 +168,9 @@ const flxParamValueType_t kParamValueTempC_D = 50;
 
 // Pressure - double value
 const flxParamValueType_t kParamValuePressure_D = 51;
+
+// Soil Moisture Reading Raw   - uint16
+const flxParamValueType_t kParamValueSoilMoistureRaw = 52;
+
+// Soil Moisture - percent
+const flxParamValueType_t kParamValueSoilMoisturePercent_F = 53;

--- a/src/core/flux_base/flxFlux.h
+++ b/src/core/flux_base/flxFlux.h
@@ -61,6 +61,20 @@ class flxFlux : public flxObjectContainer
     }
     void add(flxDevice *theDevice);
 
+    void remove(flxDevice &theDevice)
+    {
+        remove(&theDevice);
+    }
+
+    void remove(flxDevice *theDevice);
+
+    bool contains(flxDevice &theDevice)
+    {
+        return contains(&theDevice);
+    }
+
+    bool contains(flxDevice *theDevice);
+
     // This is a singleton class - so delete copy & assignment constructors
     flxFlux(flxFlux const &) = delete;
     void operator=(flxFlux const &) = delete;

--- a/src/core/flux_base/spSpark.cpp
+++ b/src/core/flux_base/spSpark.cpp
@@ -207,6 +207,18 @@ void flxFlux::add(flxDevice *theDevice)
     Devices.push_back(theDevice);
 }
 
+//---------------------------------------------------------------------------------
+// Remove a device
+void flxFlux::remove(flxDevice *theDevice)
+{
+    Devices.remove(theDevice);
+}
+
+bool flxFlux::contains(flxDevice *theDevice)
+{
+    return Devices.contains(theDevice);
+}
+
 #define kApplicationHashIDSize 24
 
 //---------------------------------------------------------------------------------

--- a/src/device/device_soilmoisture/CMakeLists.txt
+++ b/src/device/device_soilmoisture/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022-2025, SparkFun Electronics Inc.
+#
+# SPDX-License-Identifier: MIT
+#
+# Add the source files for this directory
+flux_sdk_add_source_files(flxDevSoilMoisture.h flxDevSoilMoisture.cpp)

--- a/src/device/device_soilmoisture/flxDevSoilMoisture.cpp
+++ b/src/device/device_soilmoisture/flxDevSoilMoisture.cpp
@@ -61,7 +61,7 @@ bool flxDevSoilMoisture::isConnected(flxBusI2C &i2cDriver, uint8_t address)
 //
 // Called during the startup/initialization of the driver (after the constructor is called).
 //
-// Place to initialized the underlying device library/driver
+// Place to initialize the underlying device library/driver
 //
 bool flxDevSoilMoisture::onInitialize(TwoWire &wirePort)
 {

--- a/src/device/device_soilmoisture/flxDevSoilMoisture.cpp
+++ b/src/device/device_soilmoisture/flxDevSoilMoisture.cpp
@@ -43,13 +43,15 @@ flxDevSoilMoisture::flxDevSoilMoisture()
     flxRegister(isEnabled, "Enable this sensor", "When true, this sensor is enabled");
     flxRegister(vccPin, "VCC Pin", "The power (VCC) GPIO pin connected to the soil sensor. 0 = disabled");
     flxRegister(sensorPin, "Sensor Pin", "The sensor GPIO pin connected to the soil sensor. 0 = disabled");
+    flxRegister(calibrationDry, "Calibration Dry Value", "The calibrated value for dry (0% moisture)");
+    flxRegister(calibrationWet, "Calibration Wet Value", "The calibrated value for wet (100% moisture)");
 
     // Functions
     flxRegister(calibrateLowValue, "Calibrate Low (dry) Value", "Set the 0% moist (dry) value of the sensor");
     flxRegister(calibrateHighValue, "Calibrate High (wet) Value", "Set the 100% moist value of the sensor");
 
     // Register parameters
-    flxRegister(moistureValue, "Moisture Sensor Value", "A value of 0 (dry) to 1023 (wet)", kParamValueSoilMoistureRaw);
+    flxRegister(moistureValue, "Moisture Sensor Value", "A value of dry (0) to wet", kParamValueSoilMoistureRaw);
     flxRegister(moisturePercent, "Percent Moisture", "Value between 0.0% and 100.0%", kParamValueSoilMoisturePercent_F);
 }
 
@@ -73,7 +75,7 @@ bool flxDevSoilMoisture::setupSensor(void)
 {
 
     // Pins define yet?
-    if (_pinVCC == kNoPinSet || _pinSensor == kNoPinSet || !_isEnabled)
+    if (_pinVCC == kNoPinSet || _pinSensor == kNoPinSet)
         return false;
 
     // setup our power pin - enable output, set to low
@@ -197,6 +199,9 @@ void flxDevSoilMoisture::calibrate_low_value(void)
 
     _lowCalVal = valueSum / kCalibrationIterations;
     flxLog_N(F("Calibration complete. Dry value is: %d"), _lowCalVal);
+
+    // so this value is saved
+    this->setIsDirty();
 }
 //-----------------------------------------------------------------------
 void flxDevSoilMoisture::calibrate_high_value(void)
@@ -217,5 +222,7 @@ void flxDevSoilMoisture::calibrate_high_value(void)
         flxLog_N_(".");
     }
     _highCalVal = valueSum / kCalibrationIterations;
-    flxLog_N(F("Calibration complete. 100\% Web value is: %d"), _highCalVal);
+    flxLog_N(F("Calibration complete. 100%c Web value is: %d"), '%', _highCalVal);
+    // so this value is saved
+    this->setIsDirty();
 }

--- a/src/device/device_soilmoisture/flxDevSoilMoisture.cpp
+++ b/src/device/device_soilmoisture/flxDevSoilMoisture.cpp
@@ -1,0 +1,88 @@
+/*
+ *---------------------------------------------------------------------------------
+ *
+ * Copyright (c) 2022-2025, SparkFun Electronics Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ *---------------------------------------------------------------------------------
+ */
+
+/*
+ *
+ *  flxDevSoilMoisture.cpp
+ *
+ *  Device object for the SparkFun Soil Moisture sensor.
+ *
+ *
+ *
+ */
+#include "Arduino.h"
+
+#include "flxDevSoilMoisture.h"
+
+// Define our class static variables - allocs storage for them
+
+uint8_t flxDevSoilMoisture::defaultDeviceAddress[] = {SF_SOIL_MOISTURE_DEFAULT_I2C_ADDRESS, kSparkDeviceAddressNull};
+
+//----------------------------------------------------------------------------------------------------------
+// Register this class with the system, enabling this driver during system
+// initialization and device discovery.
+
+flxRegisterDevice(flxDevSoilMoisture);
+
+//----------------------------------------------------------------------------------------------------------
+// Constructor
+//
+// Object constructor. Performs initialization of device values, including device identifiers (name, I2C address),
+// and managed properties.
+
+flxDevSoilMoisture::flxDevSoilMoisture()
+{
+
+    // Setup unique identifiers for this device and basic device object systems
+    setName(getDeviceName());
+    setDescription("The SparkFun Soil Moisture Sensor");
+
+    // Register parameters
+    flxRegister(moistureValue, "Moisture Sensor Value", "A value of 0 (wet) to 1023 (dry)", kParamValueSoilMoistureRaw);
+    flxRegister(moisturePercent, "Percent Moisture", "Value between 0.0% and 100.0%", kParamValueSoilMoisturePercent_F);
+}
+
+//----------------------------------------------------------------------------------------------------------
+// Static method used to determine if devices is connected before creating this object (if creating dynamically)
+bool flxDevSoilMoisture::isConnected(flxBusI2C &i2cDriver, uint8_t address)
+{
+    // For speed, ping the device address first
+    return i2cDriver.ping(address);
+}
+//----------------------------------------------------------------------------------------------------------
+// onInitialize()
+//
+// Called during the startup/initialization of the driver (after the constructor is called).
+//
+// Place to initialized the underlying device library/driver
+//
+bool flxDevSoilMoisture::onInitialize(TwoWire &wirePort)
+{
+
+    if (SparkFunSoilMoistureSensor::begin(flxDevice::address(), wirePort) == false)
+    {
+        flxLog_E("%s: failed to initialize", getDeviceName());
+        return false;
+    }
+
+    return true;
+}
+
+// GETTER methods for output params
+uint16_t flxDevSoilMoisture::read_moisture_value()
+{
+
+    return SparkFunSoilMoistureSensor::readMoistureValue();
+}
+
+float flxDevSoilMoisture::read_moisture_percent()
+{
+    return SparkFunSoilMoistureSensor::readMoisturePercentage();
+}

--- a/src/device/device_soilmoisture/flxDevSoilMoisture.h
+++ b/src/device/device_soilmoisture/flxDevSoilMoisture.h
@@ -1,0 +1,71 @@
+/*
+ *---------------------------------------------------------------------------------
+ *
+ * Copyright (c) 2022-2025, SparkFun Electronics Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ *---------------------------------------------------------------------------------
+ */
+
+/*
+ *
+ *  flxDevSoilMoisture.h
+ *
+ *  Device object for the SparkFun Soil Moisture sensor.
+ *
+ *
+ *
+ */
+
+#pragma once
+
+#include "Arduino.h"
+
+#include "SparkFun_Soil_Moisture_Sensor.h"
+#include "flxDevice.h"
+
+// What is the name used to ID this device?
+#define kSoilMoistureDeviceName "Soil Moisture Sensor"
+//----------------------------------------------------------------------------------------------------------
+// Define our class - note we are sub-classing from the Qwiic Library
+class flxDevSoilMoisture : public flxDeviceI2CType<flxDevSoilMoisture>, public SparkFunSoilMoistureSensor
+{
+
+  public:
+    flxDevSoilMoisture();
+
+    // Static Interface - used by the system to determine if this device is
+    // connected before the object is instantiated.
+    static bool isConnected(flxBusI2C &i2cDriver, uint8_t address);
+
+    static flxDeviceConfidence_t connectedConfidence(void)
+    {
+        return flxDevConfidencePing;
+    }
+
+    static const char *getDeviceName()
+    {
+        return kSoilMoistureDeviceName;
+    };
+
+    static const uint8_t *getDefaultAddresses()
+    {
+        return defaultDeviceAddress;
+    }
+    // holds the class list of possible addresses/IDs for this objects
+    static uint8_t defaultDeviceAddress[];
+
+    // Method called to initialize the class
+    bool onInitialize(TwoWire &);
+
+  private:
+    // methods used to get values for our output parameters
+    uint16_t read_moisture_value();
+    float read_moisture_percent();
+
+  public:
+    // Define our output parameters - specify the get functions to call.
+    flxParameterOutUInt16<flxDevSoilMoisture, &flxDevSoilMoisture::read_moisture_value> moistureValue;
+    flxParameterOutFloat<flxDevSoilMoisture, &flxDevSoilMoisture::read_moisture_percent> moisturePercent;
+};

--- a/src/device/device_soilmoisture/flxDevSoilMoisture.h
+++ b/src/device/device_soilmoisture/flxDevSoilMoisture.h
@@ -22,26 +22,20 @@
 
 #include "Arduino.h"
 
-#include "SparkFun_Soil_Moisture_Sensor.h"
 #include "flxDevice.h"
 
 // What is the name used to ID this device?
 #define kSoilMoistureDeviceName "Soil Moisture Sensor"
 //----------------------------------------------------------------------------------------------------------
-// Define our class - note we are sub-classing from the Qwiic Library
-class flxDevSoilMoisture : public flxDeviceI2CType<flxDevSoilMoisture>, public SparkFunSoilMoistureSensor
+// Define our class - This is a simple GPIO driven device
+class flxDevSoilMoisture : public flxDeviceGPIOType<flxDevSoilMoisture>
 {
 
   public:
     flxDevSoilMoisture();
 
-    // Static Interface - used by the system to determine if this device is
-    // connected before the object is instantiated.
-    static bool isConnected(flxBusI2C &i2cDriver, uint8_t address);
-
-    static flxDeviceConfidence_t connectedConfidence(void)
+    flxDevSoilMoisture(uint8_t pinVCC, uint8_t pinSensor) : _pinVCC{pinVCC}, _pinSensor{pinSensor}
     {
-        return flxDevConfidencePing;
     }
 
     static const char *getDeviceName()
@@ -49,22 +43,60 @@ class flxDevSoilMoisture : public flxDeviceI2CType<flxDevSoilMoisture>, public S
         return kSoilMoistureDeviceName;
     };
 
-    static const uint8_t *getDefaultAddresses()
-    {
-        return defaultDeviceAddress;
-    }
-    // holds the class list of possible addresses/IDs for this objects
-    static uint8_t defaultDeviceAddress[];
-
     // Method called to initialize the class
-    bool onInitialize(TwoWire &);
+    bool onInitialize(void);
 
   private:
+    // consts
+    static constexpr uint8_t kNoPinSet = 0;
+
+    // Setup Sensor
+
+    bool setupSensor(void);
+
+    // props
+    // is enabled?
+    bool get_is_enabled(void);
+    void set_is_enabled(bool);
+
+    uint8_t get_vcc_pin(void);
+    void set_vcc_pin(uint8_t);
+
+    uint8_t get_sensor_pin(void);
+    void set_sensor_pin(uint8_t);
+
     // methods used to get values for our output parameters
     uint16_t read_moisture_value();
     float read_moisture_percent();
 
+    void calibrate_low_value(void);
+    void calibrate_high_value(void);
+
+    uint8_t _pinVCC;
+    uint8_t _pinSensor;
+
+    bool _isEnabled;
+
+    uint16_t _lowCalVal;
+    uint16_t _highCalVal;
+
+    // cache the last value read - b/c value can change between read in the same observation
+    uint16_t _lastValue;
+    uint32_t _lastValueTick;
+
   public:
+    // properties
+    flxPropertyRWBool<flxDevSoilMoisture, &flxDevSoilMoisture::get_is_enabled, &flxDevSoilMoisture::set_is_enabled>
+        isEnabled = {false};
+
+    flxPropertyRWUInt8<flxDevSoilMoisture, &flxDevSoilMoisture::get_vcc_pin, &flxDevSoilMoisture::set_vcc_pin> vccPin;
+    flxPropertyRWUInt8<flxDevSoilMoisture, &flxDevSoilMoisture::get_sensor_pin, &flxDevSoilMoisture::set_sensor_pin>
+        sensorPin;
+
+    // functions
+    flxParameterInVoid<flxDevSoilMoisture, &flxDevSoilMoisture::calibrate_low_value> calibrateLowValue;
+    flxParameterInVoid<flxDevSoilMoisture, &flxDevSoilMoisture::calibrate_high_value> calibrateHighValue;
+
     // Define our output parameters - specify the get functions to call.
     flxParameterOutUInt16<flxDevSoilMoisture, &flxDevSoilMoisture::read_moisture_value> moistureValue;
     flxParameterOutFloat<flxDevSoilMoisture, &flxDevSoilMoisture::read_moisture_percent> moisturePercent;

--- a/src/device/device_soilmoisture/flxDevSoilMoisture.h
+++ b/src/device/device_soilmoisture/flxDevSoilMoisture.h
@@ -65,6 +65,23 @@ class flxDevSoilMoisture : public flxDeviceGPIOType<flxDevSoilMoisture>
     uint8_t get_sensor_pin(void);
     void set_sensor_pin(uint8_t);
 
+    uint16_t get_cal_low(void)
+    {
+        return _lowCalVal;
+    }
+    void set_cal_low(uint16_t val)
+    {
+        _lowCalVal = val;
+    }
+    uint16_t get_cal_high(void)
+    {
+        return _highCalVal;
+    }
+    void set_cal_high(uint16_t val)
+    {
+        _highCalVal = val;
+    }
+
     // methods used to get values for our output parameters
     uint16_t read_moisture_value();
     float read_moisture_percent();
@@ -92,6 +109,12 @@ class flxDevSoilMoisture : public flxDeviceGPIOType<flxDevSoilMoisture>
     flxPropertyRWUInt8<flxDevSoilMoisture, &flxDevSoilMoisture::get_vcc_pin, &flxDevSoilMoisture::set_vcc_pin> vccPin;
     flxPropertyRWUInt8<flxDevSoilMoisture, &flxDevSoilMoisture::get_sensor_pin, &flxDevSoilMoisture::set_sensor_pin>
         sensorPin;
+
+    // cal values
+    flxPropertyRWUInt16<flxDevSoilMoisture, &flxDevSoilMoisture::get_cal_low, &flxDevSoilMoisture::set_cal_low>
+        calibrationDry = {0};
+    flxPropertyRWUInt16<flxDevSoilMoisture, &flxDevSoilMoisture::get_cal_high, &flxDevSoilMoisture::set_cal_high>
+        calibrationWet = {1024};
 
     // functions
     flxParameterInVoid<flxDevSoilMoisture, &flxDevSoilMoisture::calibrate_low_value> calibrateLowValue;

--- a/src/device/device_soilmoisture/flxDevSoilMoisture.h
+++ b/src/device/device_soilmoisture/flxDevSoilMoisture.h
@@ -8,14 +8,22 @@
  *---------------------------------------------------------------------------------
  */
 
-/*
+/**
+ * @file flxDevSoilMoisture.h
+ * @brief Header file for the SparkFun Soil Moisture sensor device object.
  *
- *  flxDevSoilMoisture.h
+ * This file contains the definition of the device object for the SparkFun Soil Moisture sensor.
+ * Note - this is a GPIO device, which depends on the Soil Moisture Sensor being connected to defined GPIO pins.
+ * The required pins are VCC - a digitally controlled pin (to set low and high to power the sensor during reading),
+ * and Sensor - which is an ANALOG pin to read the sensor value. These pins are settable via properties.
  *
- *  Device object for the SparkFun Soil Moisture sensor.
+ * @details
+ * The class provides methods to initialize the sensor, read moisture values, and calibrate the sensor for dry and wet
+ * states. It also includes properties to enable the sensor, set the GPIO pins, and retrieve the moisture values.
  *
- *
- *
+ * @date 2025-03-05
+ * @version 1.0
+ * @note This file is part of the SparkFun Electronics Flux SDK.
  */
 
 #pragma once
@@ -28,22 +36,43 @@
 #define kSoilMoistureDeviceName "Soil Moisture Sensor"
 //----------------------------------------------------------------------------------------------------------
 // Define our class - This is a simple GPIO driven device
+
+/**
+ * @class flxDevSoilMoisture
+ * @brief A class to interface with the SparkFun Soil Moisture sensor.
+ *
+ * This class provides methods to initialize the sensor, read moisture values, and calibrate the sensor for dry and wet
+ * states. It also includes properties to enable the sensor, set the GPIO pins, and retrieve the moisture values.
+ */
 class flxDevSoilMoisture : public flxDeviceGPIOType<flxDevSoilMoisture>
 {
 
   public:
+    /**
+     * @brief Default constructor for the flxDevSoilMoisture class.
+     */
     flxDevSoilMoisture();
 
+    /**
+     * @brief Parameterized constructor for the flxDevSoilMoisture class.
+     * @param pinVCC The GPIO pin connected to the VCC of the soil sensor.
+     * @param pinSensor The GPIO pin connected to the sensor of the soil sensor.
+     */
     flxDevSoilMoisture(uint8_t pinVCC, uint8_t pinSensor) : _pinVCC{pinVCC}, _pinSensor{pinSensor}
     {
     }
-
+    /**
+     * @brief Get the device name.
+     * @return The name of the device.
+     */
     static const char *getDeviceName()
     {
         return kSoilMoistureDeviceName;
     };
-
-    // Method called to initialize the class
+    /**
+     * @brief Method called to initialize the class.
+     * @return True if initialization is successful, false otherwise.
+     */
     bool onInitialize(void);
 
   private:
@@ -51,7 +80,10 @@ class flxDevSoilMoisture : public flxDeviceGPIOType<flxDevSoilMoisture>
     static constexpr uint8_t kNoPinSet = 0;
 
     // Setup Sensor
-
+    /**
+     * @brief Sets up the sensor.
+     * @return True if setup is successful, false otherwise.
+     */
     bool setupSensor(void);
 
     // props


### PR DESCRIPTION
Added support for the sparkfun SOIL MOISTURE sensor. This is the GPIO sensor, since the I2C / QWIIC sensor had terrible clock stretching that impacted application performance. 

This also introduces a new device type GPIO. 